### PR TITLE
Fix markup typo in write/index.html

### DIFF
--- a/write/index.html
+++ b/write/index.html
@@ -21,7 +21,7 @@
 
 
 
-<div id="variable" class="row white variable"><div>
+<div id="variable" class="row white variable">
 
 
   <div class="ctrl">
@@ -46,7 +46,7 @@
       </label>
     </div>
   </div>
-</div></div>
+</div>
 <div class="row white variable-sample-row">
   <div class="variable-sample" contenteditable spellcheck="false">
   I am Min Sans :)<br>


### PR DESCRIPTION
## Summary
- remove an accidental extra `<div>` in the variable font demo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eb3fadf5c832f85563c212e32932d