### PR TITLE
Add exit highlight and touch drag to Rush Hour

### DIFF
--- a/rush-hour/index.html
+++ b/rush-hour/index.html
@@ -14,9 +14,12 @@
 <script>
 const boardSize=6;
 const cellSize=80;
+const exitRow=2;
+const exitWidth=20;
+const boardPixelSize=boardSize*cellSize;
 const canvas=document.getElementById('board');
-canvas.width=boardSize*cellSize;
-canvas.height=boardSize*cellSize;
+canvas.width=boardPixelSize+exitWidth;
+canvas.height=boardPixelSize;
 const ctx=canvas.getContext('2d');
 function randColor(){return 'hsl('+Math.random()*360+',60%,70%)';}
 function generatePuzzle(){
@@ -55,13 +58,15 @@ function draw(){
   for(let i=0;i<=boardSize;i++){
     ctx.beginPath();
     ctx.moveTo(i*cellSize,0);
-    ctx.lineTo(i*cellSize,canvas.height);
+    ctx.lineTo(i*cellSize,boardPixelSize);
     ctx.stroke();
     ctx.beginPath();
     ctx.moveTo(0,i*cellSize);
-    ctx.lineTo(canvas.width,i*cellSize);
+    ctx.lineTo(boardPixelSize,i*cellSize);
     ctx.stroke();
   }
+  ctx.fillStyle='green';
+  ctx.fillRect(boardPixelSize,exitRow*cellSize+2,exitWidth,cellSize-4);
   for(const car of cars){
     ctx.fillStyle=car.color;
     const x=car.x*cellSize;
@@ -95,7 +100,7 @@ function isFree(x,y,ignore){
 function tryMove(car,newX,newY){
   if(car.dir==='H'){if(newY!==car.y)return;for(let i=0;i<car.length;i++)if(!isFree(newX+i,newY,car))return;car.x=newX;}
   else{if(newX!==car.x)return;for(let i=0;i<car.length;i++)if(!isFree(newX,newY+i,car))return;car.y=newY;}
-  if(car.red&&car.x+car.length===boardSize&&car.y===2)setTimeout(()=>alert('성공!'),50);
+  if(car.red&&car.x+car.length===boardSize&&car.y===exitRow)setTimeout(()=>alert('성공!'),50);
 }
 canvas.addEventListener('mousedown',e=>{
   const rect=canvas.getBoundingClientRect();
@@ -104,6 +109,15 @@ canvas.addEventListener('mousedown',e=>{
   const car=carAt(x,y);
   if(car)selected={car,ox:car.x,oy:car.y,sx:e.clientX,sy:e.clientY};
 });
+canvas.addEventListener('touchstart',e=>{
+  const t=e.touches[0];
+  const rect=canvas.getBoundingClientRect();
+  const x=Math.floor((t.clientX-rect.left)/cellSize);
+  const y=Math.floor((t.clientY-rect.top)/cellSize);
+  const car=carAt(x,y);
+  if(car)selected={car,ox:car.x,oy:car.y,sx:t.clientX,sy:t.clientY};
+  e.preventDefault();
+},{passive:false});
 window.addEventListener('mousemove',e=>{
   if(!selected)return;
   const car=selected.car;
@@ -113,7 +127,19 @@ window.addEventListener('mousemove',e=>{
   else tryMove(car,car.x,selected.oy+dy);
   draw();
 });
+window.addEventListener('touchmove',e=>{
+  if(!selected)return;
+  const t=e.touches[0];
+  const car=selected.car;
+  const dx=Math.round((t.clientX-selected.sx)/cellSize);
+  const dy=Math.round((t.clientY-selected.sy)/cellSize);
+  if(car.dir==='H')tryMove(car,selected.ox+dx,car.y);
+  else tryMove(car,car.x,selected.oy+dy);
+  draw();
+  e.preventDefault();
+},{passive:false});
 window.addEventListener('mouseup',()=>{selected=null;});
+window.addEventListener('touchend',()=>{selected=null;},{passive:false});
 draw();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- highlight the exit on the Rush Hour board
- resize the canvas and update drawing logic
- add touch support for dragging cars

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852bddca060832fb188cd37d04ca537