### PR TITLE
Add difficulty selection system to rush-hour game

### DIFF
--- a/rush-hour/index.html
+++ b/rush-hour/index.html
@@ -6,11 +6,28 @@
 <title>Rush Hour</title>
 <style>
   body{display:flex;justify-content:center;align-items:center;height:100vh;margin:0;background:#f0f0f0;font-family:sans-serif;}
+  #start button{margin:0 5px;padding:10px 15px;}
   canvas{background:#fff;box-shadow:0 0 10px rgba(0,0,0,0.5);}
+  #dialog{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);display:flex;justify-content:center;align-items:center;}
+  #dialogContent{background:#fff;padding:20px;text-align:center;}
+  .hidden{display:none;}
 </style>
 </head>
 <body>
-<canvas id="board"></canvas>
+<div id="start">
+  <button data-level="1">난이도1</button>
+  <button data-level="2">난이도2</button>
+  <button data-level="3">난이도3</button>
+  <button data-level="4">난이도4</button>
+  <button data-level="5">난이도5</button>
+</div>
+<canvas id="board" class="hidden"></canvas>
+<div id="dialog" class="hidden">
+  <div id="dialogContent">
+    <p>성공!</p>
+    <button id="restartBtn">재시작</button>
+  </div>
+</div>
 <script type="module" src="js/game.js"></script>
 </body>
 </html>

--- a/rush-hour/js/game.js
+++ b/rush-hour/js/game.js
@@ -1,4 +1,4 @@
-import {generateRandomPuzzle, defaultPuzzles} from './puzzles.js';
+import {generatePuzzleByDifficulty, solvePuzzle, classifyDifficulty} from './puzzles.js';
 
 const boardSize=6;
 const cellSize=80;
@@ -9,10 +9,13 @@ const canvas=document.getElementById('board');
 canvas.width=boardPixelSize+exitWidth;
 canvas.height=boardPixelSize;
 const ctx=canvas.getContext('2d');
+const startDiv=document.getElementById('start');
+const dialog=document.getElementById('dialog');
+const restartBtn=document.getElementById('restartBtn');
 
-let puzzles=defaultPuzzles;
-let cars=JSON.parse(JSON.stringify(puzzles[Math.floor(Math.random()*puzzles.length)]));
+let cars=[];
 let selected=null;
+let currentLevel=1;
 
 function draw(){
   ctx.clearRect(0,0,canvas.width,canvas.height);
@@ -37,6 +40,9 @@ function draw(){
     const h=car.dir==='V'?car.length*cellSize:cellSize;
     ctx.fillRect(x+2,y+2,w-4,h-4);
   }
+  ctx.fillStyle='#000';
+  ctx.font='16px sans-serif';
+  ctx.fillText('난이도 '+currentLevel,10,20);
 }
 
 function carAt(x,y){
@@ -65,7 +71,7 @@ function isFree(x,y,ignore){
 function tryMove(car,newX,newY){
   if(car.dir==='H'){if(newY!==car.y)return;for(let i=0;i<car.length;i++)if(!isFree(newX+i,newY,car))return;car.x=newX;}
   else{if(newX!==car.x)return;for(let i=0;i<car.length;i++)if(!isFree(newX,newY+i,car))return;car.y=newY;}
-  if(car.red&&car.x+car.length===boardSize&&car.y===exitRow)setTimeout(()=>alert('성공!'),50);
+  if(car.red&&car.x+car.length===boardSize&&car.y===exitRow)setTimeout(()=>{dialog.classList.remove('hidden');},50);
 }
 
 canvas.addEventListener('mousedown',e=>{
@@ -111,4 +117,23 @@ window.addEventListener('touchmove',e=>{
 window.addEventListener('mouseup',()=>{selected=null;});
 window.addEventListener('touchend',()=>{selected=null;},{passive:false});
 
-draw();
+function startGame(level){
+  const puzzle=generatePuzzleByDifficulty(level);
+  if(!puzzle){alert('문제 생성 실패');return;}
+  cars=JSON.parse(JSON.stringify(puzzle));
+  currentLevel=classifyDifficulty(solvePuzzle(cars));
+  startDiv.classList.add('hidden');
+  dialog.classList.add('hidden');
+  canvas.classList.remove('hidden');
+  draw();
+}
+
+startDiv.querySelectorAll('button').forEach(btn=>{
+  btn.addEventListener('click',()=>startGame(parseInt(btn.dataset.level,10)));
+});
+
+restartBtn.onclick=()=>{
+  dialog.classList.add('hidden');
+  canvas.classList.add('hidden');
+  startDiv.classList.remove('hidden');
+};

--- a/rush-hour/js/puzzles.js
+++ b/rush-hour/js/puzzles.js
@@ -2,6 +2,78 @@ export function randColor(){
   return 'hsl(' + Math.random()*360 + ',60%,70%)';
 }
 
+function copyCars(cars){
+  return cars.map(c=>({x:c.x,y:c.y,length:c.length,dir:c.dir,color:c.color,red:c.red}));
+}
+
+function boardKey(cars){
+  return cars.map(c=>c.x+','+c.y).join('|');
+}
+
+function isFree(x,y,cars,ignore,boardSize){
+  for(const c of cars){
+    if(c===ignore)continue;
+    for(let i=0;i<c.length;i++){
+      const cx=c.dir==='H'?c.x+i:c.x;
+      const cy=c.dir==='V'?c.y+i:c.y;
+      if(cx===x&&cy===y)return false;
+    }
+  }
+  return x>=0&&x<boardSize&&y>=0&&y<boardSize;
+}
+
+export function solvePuzzle(startCars,boardSize=6,maxDepth=40){
+  const exitRow=2;
+  const start=copyCars(startCars);
+  const queue=[{cars:start,depth:0}];
+  const visited=new Set();
+  while(queue.length){
+    const {cars,depth}=queue.shift();
+    const key=boardKey(cars);
+    if(visited.has(key))continue;
+    visited.add(key);
+    const red=cars.find(c=>c.red);
+    if(red.x+red.length===boardSize&&red.y===exitRow)return depth;
+    if(depth>=maxDepth)continue;
+    for(let i=0;i<cars.length;i++){
+      const car=cars[i];
+      if(car.dir==='H'){
+        for(let nx=car.x-1;isFree(nx,car.y,cars,car,boardSize);nx--){
+          const next=copyCars(cars);next[i].x=nx;queue.push({cars:next,depth:depth+1});
+        }
+        for(let nx=car.x+1;isFree(nx+car.length-1,car.y,cars,car,boardSize);nx++){
+          const next=copyCars(cars);next[i].x=nx;queue.push({cars:next,depth:depth+1});
+        }
+      }else{
+        for(let ny=car.y-1;isFree(car.x,ny,cars,car,boardSize);ny--){
+          const next=copyCars(cars);next[i].y=ny;queue.push({cars:next,depth:depth+1});
+        }
+        for(let ny=car.y+1;isFree(car.x,ny+car.length-1,cars,car,boardSize);ny++){
+          const next=copyCars(cars);next[i].y=ny;queue.push({cars:next,depth:depth+1});
+        }
+      }
+    }
+  }
+  return -1;
+}
+
+export function classifyDifficulty(moves){
+  if(moves<=10)return 1;
+  if(moves<=20)return 2;
+  if(moves<=30)return 3;
+  if(moves<=40)return 4;
+  return 5;
+}
+
+export function generatePuzzleByDifficulty(level,boardSize=6){
+  for(let i=0;i<1000;i++){
+    const puzzle=generateRandomPuzzle(boardSize);
+    const moves=solvePuzzle(puzzle,boardSize,60);
+    if(moves>0&&classifyDifficulty(moves)===level)return puzzle;
+  }
+  return null;
+}
+
 export function generateRandomPuzzle(boardSize=6){
   const cars=[{x:0,y:2,length:2,dir:'H',color:'red',red:true}];
   let attempts=0;


### PR DESCRIPTION
## Summary
- add BFS solver and puzzle difficulty classification
- generate rush-hour puzzles by difficulty
- add UI for difficulty selection and restart dialog

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685353364a24832f9ec44113f99f77d7