### PR TITLE
Modify restart dialog in Rush Hour

### DIFF
--- a/rush-hour/js/game.js
+++ b/rush-hour/js/game.js
@@ -13,6 +13,11 @@ const startDiv=document.getElementById('start');
 const dialog=document.getElementById('dialog');
 const restartBtn=document.getElementById('restartBtn');
 
+// Ensure start screen is visible and dialog hidden on initial load
+startDiv.classList.remove('hidden');
+dialog.classList.add('hidden');
+canvas.classList.add('hidden');
+
 let cars=[];
 let selected=null;
 let currentLevel=1;
@@ -136,4 +141,6 @@ restartBtn.onclick=()=>{
   dialog.classList.add('hidden');
   canvas.classList.add('hidden');
   startDiv.classList.remove('hidden');
+  cars=[];
+  selected=null;
 };


### PR DESCRIPTION
## Summary
- hide restart dialog on initial load
- reset game state when clicking the restart button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853f5a4c41c832fad7adde2db64c6c5