### PR TITLE
Add icon-font tool skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+pnpm-lock.yaml
+dist
+tmp

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "icon-font-tool-root",
+  "private": true,
+  "workspaces": ["packages/*"],
+  "scripts": {
+    "dev": "concurrently \"pnpm --filter icon-font-server dev\" \"pnpm --filter icon-font-client dev\"",
+    "test": "pnpm --recursive test"
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.1"
+  }
+}

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Icon Font Tool</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "icon-font-client",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.1.4"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.27",
+    "@types/react-dom": "^18.0.10",
+    "@vitejs/plugin-react": "^3.1.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0",
+    "vitest": "^0.34.1"
+  }
+}

--- a/packages/client/src/components/DownloadPanel.tsx
+++ b/packages/client/src/components/DownloadPanel.tsx
@@ -1,0 +1,3 @@
+export default function DownloadPanel() {
+  return <div>Download panel</div>;
+}

--- a/packages/client/src/components/IconGrid.tsx
+++ b/packages/client/src/components/IconGrid.tsx
@@ -1,0 +1,3 @@
+export default function IconGrid() {
+  return <div>Icon grid placeholder</div>;
+}

--- a/packages/client/src/components/StrokeSlider.tsx
+++ b/packages/client/src/components/StrokeSlider.tsx
@@ -1,0 +1,16 @@
+import useStore from '../store';
+
+export default function StrokeSlider() {
+  const factor = useStore(s => s.factor);
+  const setFactor = useStore(s => s.setFactor);
+  return (
+    <input
+      type="range"
+      min={0.2}
+      max={5}
+      step={0.1}
+      value={factor}
+      onChange={e => setFactor(parseFloat(e.target.value))}
+    />
+  );
+}

--- a/packages/client/src/components/UploadZone.tsx
+++ b/packages/client/src/components/UploadZone.tsx
@@ -1,0 +1,16 @@
+import { ChangeEvent } from 'react';
+import useStore from '../store';
+
+export default function UploadZone() {
+  const setSession = useStore(s => s.setSession);
+  const onChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    const form = new FormData();
+    Array.from(files).forEach(f => form.append('files', f));
+    const res = await fetch('/api/upload', { method: 'POST', body: form });
+    const data = await res.json();
+    setSession(data.sessionId);
+  };
+  return <input type="file" multiple accept=".svg" onChange={onChange} />;
+}

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import UploadZone from './components/UploadZone';
+import StrokeSlider from './components/StrokeSlider';
+import IconGrid from './components/IconGrid';
+import DownloadPanel from './components/DownloadPanel';
+
+const App = () => (
+  <div>
+    <UploadZone />
+    <StrokeSlider />
+    <IconGrid />
+    <DownloadPanel />
+  </div>
+);
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -1,0 +1,17 @@
+import create from 'zustand';
+
+interface State {
+  sessionId: string | null;
+  factor: number;
+  setSession: (id: string) => void;
+  setFactor: (n: number) => void;
+}
+
+const useStore = create<State>(set => ({
+  sessionId: null,
+  factor: 1,
+  setSession: id => set({ sessionId: id }),
+  setFactor: n => set({ factor: n })
+}));
+
+export default useStore;

--- a/packages/client/test/store.test.ts
+++ b/packages/client/test/store.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import useStore from '../src/store';
+
+describe('store', () => {
+  it('updates factor', () => {
+    useStore.getState().setFactor(2);
+    expect(useStore.getState().factor).toBe(2);
+  });
+});

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["DOM", "ES2022"],
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000'
+    }
+  }
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "icon-font-server",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node-dev --respawn src/index.ts",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "multer": "^1.4.5",
+    "archiver": "^5.3.1",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/node": "^20.4.2",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.2.2",
+    "vitest": "^0.34.1",
+    "supertest": "^6.3.3"
+  }
+}

--- a/packages/server/scripts/build_variable_font.py
+++ b/packages/server/scripts/build_variable_font.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+print('stub')

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import multer from 'multer';
+import { v4 as uuidv4 } from 'uuid';
+import fs from 'fs';
+import path from 'path';
+
+const app = express();
+app.use(express.json());
+
+const upload = multer({
+  limits: { fileSize: 2 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    if (file.mimetype === 'image/svg+xml') cb(null, true);
+    else cb(new Error('Invalid file type'));
+  }
+});
+
+app.post('/api/upload', upload.array('files', 200), (req, res) => {
+  const files = req.files as Express.Multer.File[];
+  const sessionId = uuidv4();
+  const dest = path.join('/tmp', sessionId, 'raw');
+  fs.mkdirSync(dest, { recursive: true });
+  files.forEach(f => {
+    fs.writeFileSync(path.join(dest, f.originalname), f.buffer);
+  });
+  res.json({ sessionId });
+});
+
+app.patch('/api/stroke-weight', (req, res) => {
+  const { factor } = req.body as { factor: number };
+  if (typeof factor !== 'number') return res.status(400).end();
+  // TODO: implement stroke weight adjustment
+  res.json({ ok: true });
+});
+
+app.post('/api/build-subset', (req, res) => {
+  const { selected } = req.body as { selected: string[] };
+  if (!Array.isArray(selected)) return res.status(400).end();
+  // TODO: call python script and package fonts
+  res.json({ ok: true });
+});
+
+const port = process.env.PORT || 3000;
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => console.log(`Server running on ${port}`));
+}
+
+export default app;

--- a/packages/server/test/fixtures/simple.svg
+++ b/packages/server/test/fixtures/simple.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+  <circle cx="5" cy="5" r="5" stroke="black"/>
+</svg>

--- a/packages/server/test/upload.test.ts
+++ b/packages/server/test/upload.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import app from '../src/index';
+import path from 'path';
+
+const svgPath = path.join(__dirname, 'fixtures', 'simple.svg');
+
+describe('upload', () => {
+  it('rejects non-svg', async () => {
+    const res = await request(app)
+      .post('/api/upload')
+      .attach('files', Buffer.from('abc'), 'a.txt');
+    expect(res.status).toBe(500); // multer error
+  });
+});

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'


### PR DESCRIPTION
## Summary
- configure pnpm monorepo
- set up express server with upload and placeholder endpoints
- add python font build stub
- create React client with Zustand store
- basic vitest unit tests for both packages

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/concurrently: Forbidden)*
- `pnpm test` *(fails: vitest not found because dependencies didn't install)*

------
https://chatgpt.com/codex/tasks/task_e_685bdab09898832f95cc9549b71e354a