### PR TITLE
image-splitter: 고정 높이 대신 비율 선택으로 자르기 기능 변경

### DIFF
--- a/image-splitter/index.html
+++ b/image-splitter/index.html
@@ -23,12 +23,27 @@
         <main>
             <div class="control-panel">
                 <div class="input-group">
-                    <label for="splitHeight">Split Height (px)</label>
-                    <input type="number" id="splitHeight" value="1080" min="10">
+                    <label for="cropRatio">자르기 비율</label>
+                    <select id="cropRatio">
+                        <option value="3:4" selected>3:4 (세로, 기본)</option>
+                        <option value="1:1">1:1 (정사각형)</option>
+                        <option value="4:3">4:3 (가로)</option>
+                        <option value="9:16">9:16 (세로 영상)</option>
+                        <option value="16:9">16:9 (가로 영상)</option>
+                        <option value="custom">사용자 지정</option>
+                    </select>
                 </div>
                 <div class="input-group">
-                    <label for="gapHeight">Gap to Ignore (px)</label>
+                    <label for="gapHeight">무시할 간격 (px)</label>
                     <input type="number" id="gapHeight" value="20" min="0">
+                </div>
+                <div class="input-group custom-ratio-group" id="customRatioGroup">
+                    <label>사용자 지정 비율 (가로 : 세로)</label>
+                    <div class="ratio-inputs">
+                        <input type="number" id="customRatioW" value="3" min="1">
+                        <span>:</span>
+                        <input type="number" id="customRatioH" value="4" min="1">
+                    </div>
                 </div>
             </div>
 

--- a/image-splitter/script.js
+++ b/image-splitter/script.js
@@ -3,10 +3,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const uploadZone = document.getElementById('uploadZone');
     const processBtn = document.getElementById('processBtn');
     const resultsArea = document.getElementById('resultsArea');
-    const splitHeightInput = document.getElementById('splitHeight');
+    const cropRatioSelect = document.getElementById('cropRatio');
+    const customRatioGroup = document.getElementById('customRatioGroup');
+    const customRatioW = document.getElementById('customRatioW');
+    const customRatioH = document.getElementById('customRatioH');
     const gapHeightInput = document.getElementById('gapHeight');
 
     let selectedFiles = [];
+
+    // Show/hide custom ratio inputs
+    cropRatioSelect.addEventListener('change', () => {
+        customRatioGroup.classList.toggle('visible', cropRatioSelect.value === 'custom');
+    });
 
     // Drag & Drop Handling
     uploadZone.addEventListener('dragover', (e) => {
@@ -38,36 +46,44 @@ document.addEventListener('DOMContentLoaded', () => {
             if (selectedFiles.length > 0) {
                 processBtn.disabled = false;
                 processBtn.textContent = `Process ${selectedFiles.length} Image${selectedFiles.length > 1 ? 's' : ''}`;
-                // Optional: Show preview of selected files names?
             } else {
                 alert('Please select valid image files.');
             }
         }
     }
 
+    function getRatio() {
+        if (cropRatioSelect.value === 'custom') {
+            const w = parseFloat(customRatioW.value) || 3;
+            const h = parseFloat(customRatioH.value) || 4;
+            return { w, h };
+        }
+        const [w, h] = cropRatioSelect.value.split(':').map(Number);
+        return { w, h };
+    }
+
     processBtn.addEventListener('click', async () => {
-        const splitHeight = parseInt(splitHeightInput.value, 10);
+        const { w: ratioW, h: ratioH } = getRatio();
         const gapHeight = parseInt(gapHeightInput.value, 10) || 0;
 
-        if (!splitHeight || splitHeight <= 0) {
-            alert('Please enter a valid split height.');
+        if (!ratioW || !ratioH || ratioW <= 0 || ratioH <= 0) {
+            alert('유효한 비율을 입력해주세요.');
             return;
         }
 
         processBtn.disabled = true;
         processBtn.textContent = 'Processing...';
-        resultsArea.innerHTML = ''; // Clear previous results
+        resultsArea.innerHTML = '';
 
         for (const file of selectedFiles) {
-            await processImage(file, splitHeight, gapHeight);
+            await processImage(file, ratioW, ratioH, gapHeight);
         }
 
         processBtn.disabled = false;
         processBtn.textContent = 'Process Images';
     });
 
-    async function processImage(file, splitHeight, gap) {
-        // Create a result card
+    async function processImage(file, ratioW, ratioH, gap) {
         const card = document.createElement('div');
         card.className = 'result-card';
         card.innerHTML = `
@@ -83,6 +99,9 @@ document.addEventListener('DOMContentLoaded', () => {
             const width = imgBitmap.width;
             const height = imgBitmap.height;
 
+            // Calculate split height from image width and ratio
+            const splitHeight = Math.round(width * (ratioH / ratioW));
+
             const zip = new JSZip();
             const folder = zip.folder(file.name.replace(/\.[^/.]+$/, ""));
 
@@ -95,42 +114,31 @@ document.addEventListener('DOMContentLoaded', () => {
             canvas.width = width;
 
             while (currentY < height) {
-                // Determine height of this chunk
                 let chunkHeight = splitHeight;
 
-                // If this chunk goes beyond image, clip it
                 if (currentY + chunkHeight > height) {
                     chunkHeight = height - currentY;
                 }
 
-                // If chunkHeight is 0 or less (shouldn't happen with logic, but safety), break
                 if (chunkHeight <= 0) break;
 
-                // Resize canvas for this chunk
                 canvas.height = chunkHeight;
-
-                // Draw
                 ctx.drawImage(imgBitmap, 0, currentY, width, chunkHeight, 0, 0, width, chunkHeight);
 
-                // Convert to blob
                 const blob = await new Promise(resolve => canvas.toBlob(resolve, file.type || 'image/png'));
 
-                // Add to zip
                 const ext = file.name.split('.').pop() || 'png';
                 const partName = `${file.name.replace(/\.[^/.]+$/, "")}_${String(partIndex).padStart(2, '0')}.${ext}`;
                 folder.file(partName, blob);
 
                 chunks.push(partName);
 
-                // Move Y
                 currentY += splitHeight + gap;
                 partIndex++;
             }
 
-            // Generate Zip
             const content = await zip.generateAsync({ type: "blob" });
 
-            // Update Card
             card.innerHTML = `
                 <div class="result-header">
                     <h3>${file.name}</h3>

--- a/image-splitter/style.css
+++ b/image-splitter/style.css
@@ -97,6 +97,7 @@ header p {
 }
 
 .input-group select {
+    width: 100%;
     background: var(--bg-color);
     border: 1px solid var(--border-color);
     color: var(--text-primary);
@@ -106,6 +107,8 @@ header p {
     font-size: 1rem;
     transition: var(--transition);
     cursor: pointer;
+    -webkit-appearance: none;
+    -moz-appearance: none;
     appearance: none;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
     background-repeat: no-repeat;

--- a/image-splitter/style.css
+++ b/image-splitter/style.css
@@ -96,6 +96,60 @@ header p {
     box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
 }
 
+.input-group select {
+    background: var(--bg-color);
+    border: 1px solid var(--border-color);
+    color: var(--text-primary);
+    padding: 0.8rem;
+    border-radius: 0.5rem;
+    font-family: var(--font-main);
+    font-size: 1rem;
+    transition: var(--transition);
+    cursor: pointer;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.8rem center;
+    padding-right: 2.2rem;
+}
+
+.input-group select:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+}
+
+.input-group select option {
+    background: var(--card-bg);
+}
+
+/* Custom ratio row */
+.custom-ratio-group {
+    grid-column: 1 / -1;
+    display: none;
+}
+
+.custom-ratio-group.visible {
+    display: flex;
+}
+
+.ratio-inputs {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.ratio-inputs input {
+    width: 80px;
+    text-align: center;
+}
+
+.ratio-inputs span {
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
 /* Upload Zone */
 .upload-zone {
     background: rgba(30, 41, 59, 0.5);


### PR DESCRIPTION
- Split Height 입력 → 비율 선택 드롭다운으로 교체 (기본값: 3:4)
- 프리셋: 3:4, 1:1, 4:3, 9:16, 16:9 및 사용자 지정
- 사용자 지정 선택 시 가로:세로 직접 입력 가능
- splitHeight = 이미지 너비 × (비율 높이 / 비율 너비) 로 자동 계산

https://claude.ai/code/session_013kiHgGJQTqpdqiCzvudvoA