### PR TITLE
image-splitter: 샘플 이미지 다운로드 기능 추가

### DIFF
--- a/image-splitter/index.html
+++ b/image-splitter/index.html
@@ -61,6 +61,7 @@
             </div>
 
             <div class="action-bar">
+                <button id="sampleBtn" class="secondary-btn">샘플 이미지 다운로드</button>
                 <button id="processBtn" class="primary-btn" disabled>
                     Process Images
                 </button>

--- a/image-splitter/script.js
+++ b/image-splitter/script.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const customRatioW = document.getElementById('customRatioW');
     const customRatioH = document.getElementById('customRatioH');
     const gapHeightInput = document.getElementById('gapHeight');
+    const sampleBtn = document.getElementById('sampleBtn');
 
     let selectedFiles = [];
 
@@ -61,6 +62,44 @@ document.addEventListener('DOMContentLoaded', () => {
         const [w, h] = cropRatioSelect.value.split(':').map(Number);
         return { w, h };
     }
+
+    sampleBtn.addEventListener('click', () => {
+        const { w: ratioW, h: ratioH } = getRatio();
+        const gap = parseInt(gapHeightInput.value, 10) || 0;
+
+        const sampleWidth = 1080;
+        const sectionHeight = Math.round(sampleWidth * (ratioH / ratioW));
+        const totalHeight = 10 * sectionHeight + 9 * gap;
+
+        const canvas = document.createElement('canvas');
+        canvas.width = sampleWidth;
+        canvas.height = totalHeight;
+        const ctx = canvas.getContext('2d');
+
+        // 밝은 회색 배경 (무시할 간격 영역)
+        ctx.fillStyle = '#d1d5db';
+        ctx.fillRect(0, 0, sampleWidth, totalHeight);
+
+        // 10개 흰색 섹션 (잘려질 영역)
+        const fontSize = Math.min(Math.round(sectionHeight * 0.25), 220);
+        ctx.font = `bold ${fontSize}px Arial`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+
+        for (let i = 0; i < 10; i++) {
+            const y = i * (sectionHeight + gap);
+            ctx.fillStyle = '#ffffff';
+            ctx.fillRect(0, y, sampleWidth, sectionHeight);
+
+            // 섹션 번호 (연한 회색 워터마크)
+            ctx.fillStyle = '#e5e7eb';
+            ctx.fillText(String(i + 1).padStart(2, '0'), sampleWidth / 2, y + sectionHeight / 2);
+        }
+
+        canvas.toBlob(blob => {
+            saveAs(blob, 'sample_image.png');
+        }, 'image/png');
+    });
 
     processBtn.addEventListener('click', async () => {
         const { w: ratioW, h: ratioH } = getRatio();

--- a/image-splitter/style.css
+++ b/image-splitter/style.css
@@ -206,6 +206,27 @@ header p {
 .action-bar {
     display: flex;
     justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.secondary-btn {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    padding: 1rem 2rem;
+    font-size: 1rem;
+    font-weight: 600;
+    border-radius: 3rem;
+    font-family: var(--font-main);
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.secondary-btn:hover {
+    border-color: var(--accent-color);
+    color: var(--text-primary);
 }
 
 .primary-btn {


### PR DESCRIPTION
- 현재 설정(비율, 간격)을 반영한 1080px 샘플 이미지 생성
- 잘려질 영역: 흰색, 무시할 간격 영역: 밝은 회색(#d1d5db)
- 10개 섹션, 각 섹션에 연한 회색 번호 워터마크
- '샘플 이미지 다운로드' secondary 버튼 UI 추가

https://claude.ai/code/session_013kiHgGJQTqpdqiCzvudvoA